### PR TITLE
support spree 3-1-stable and Spree.user_class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-version = '3-0-stable'
+version = '3-1-stable'
 gem 'spree', github: 'spree/spree', branch: version
 gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: version
 

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,3 +1,3 @@
-Spree::User.class_eval do
+Spree.user_class.class_eval do
   has_many :payments, through: :orders
 end

--- a/spec/controllers/spree/admin/banks_controller_spec.rb
+++ b/spec/controllers/spree/admin/banks_controller_spec.rb
@@ -6,7 +6,7 @@ describe Spree::Admin::BanksController, type: :controller do
   let(:roles) { [role] }
 
   before(:each) do
-    @user = mock_model(Spree::User, :generate_spree_api_key! => false)
+    @user = mock_model(Spree.user_class, :generate_spree_api_key! => false)
     allow(@user).to receive_message_chain(:roles, :includes).and_return([])
     allow(@user).to receive(:has_spree_role?).with('admin').and_return(true)
     allow(controller).to receive(:spree_user_signed_in?).and_return(true)

--- a/spec/controllers/spree/content_controller_spec.rb
+++ b/spec/controllers/spree/content_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::ContentController, type: :controller do
   before do
     allow(controller).to receive(:authenticate_spree_user!).and_return(true)
-    @user = mock_model(Spree::User, :generate_spree_api_key! => false, last_incomplete_spree_order: nil)
+    @user = mock_model(Spree.user_class, :generate_spree_api_key! => false, last_incomplete_spree_order: nil)
     allow(controller).to receive(:spree_current_user).and_return(@user)
   end
 

--- a/spec/controllers/spree/payments_controller_spec.rb
+++ b/spec/controllers/spree/payments_controller_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Spree::PaymentsController, type: :controller do
   before do
     allow(controller).to receive(:authenticate_spree_user!).and_return(true)
-    @user = mock_model(Spree::User, :generate_spree_api_key! => false, last_incomplete_spree_order: nil)
+    @user = mock_model(Spree.user_class, :generate_spree_api_key! => false, last_incomplete_spree_order: nil)
     allow(controller).to receive(:spree_current_user).and_return(@user)
 
     @payment = mock_model(Spree::Payment)

--- a/spec/models/spree/user_spec.rb
+++ b/spec/models/spree/user_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
-describe Spree::User, type: :model do
+describe Spree.user_class, type: :model do
   it { is_expected.to have_many(:payments).through(:orders) }
 end

--- a/spree_bank_transfer.gemspec
+++ b/spree_bank_transfer.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree-bank-transfer'
-  s.version     = '3.0.0'
+  s.version     = '3.1.0'
   s.summary     = 'Spree extension to create bank transfer payment method.'
   s.description = 'This Spree extension allows admin to provide bank transfer payment method to its users.'
   s.required_ruby_version = '>= 1.9.3'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.0.0'
+  s.add_dependency 'spree_core', '~> 3.1.0.beta'
   s.add_dependency 'sqlite3', '~> 1.3.10'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'


### PR DESCRIPTION
I use it with spree 3-1-stable. It works and I changed to support `Spree.user_class`

I doesn't run rspec. Does someone help to test it for this pull request?