### PR TITLE
Update master to Spree 3.2.0.rc2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,19 @@
 source 'https://rubygems.org'
 
 # Provides basic authentication functionality for testing parts of your engine
-version = '3-1-stable'
-gem 'spree', github: 'spree/spree', branch: version
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: version
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', branch: 'master'
 
-gem 'coffee-rails', ' ~> 4.0.1'
+gem 'coffee-rails', ' ~> 4.2'
 gem 'sass-rails', '~> 5.0.1'
 
 group :test do
   gem 'minitest'
-  gem 'rspec-rails', '~> 3.4.0'
+  gem 'rspec-rails', '~> 3.4'
   gem 'shoulda-matchers', '~> 3.1.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.3'
   gem 'simplecov', require: false
   gem 'database_cleaner'
+  gem 'rails-controller-testing'
 end
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'shoulda-matchers', '~> 3.1.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.3'
   gem 'simplecov', require: false
-  gem 'database_cleaner'
-  gem 'rails-controller-testing'
+  gem 'database_cleaner', '~> 1.5.3'
+  gem 'rails-controller-testing', '~> 1.0.1'
 end
 gemspec

--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ gem 'spree-bank-transfer', require: 'spree_bank_transfer'
 
 For older versions of Spree.
 ```ruby
+# Spree 3.2.x
+gem 'spree-bank-transfer', '3.2.0', require: 'spree_bank_transfer'
+
+or
+
+gem 'spree-bank-transfer', require: 'spree_bank_transfer', github: 'vinsol-spree-contrib/spree_bank_transfer', branch: 'master'
+```
+
+```ruby
+# Spree 3.1.x
+gem 'spree-bank-transfer', '3.1.0', require: 'spree_bank_transfer'
+
+or
+
+gem 'spree-bank-transfer', require: 'spree_bank_transfer', github: 'vinsol-spree-contrib/spree_bank_transfer', branch: '3-1-stable'
+```
+
+```ruby
+# Spree 3.0.x
+gem 'spree-bank-transfer', '3.0.0', require: 'spree_bank_transfer'
+
+or
+
+gem 'spree-bank-transfer', require: 'spree_bank_transfer', github: 'vinsol-spree-contrib/spree_bank_transfer', branch: '3-0-stable'
+```
+
+```ruby
 # Spree 2.1.0
 gem 'spree-bank-transfer', '2.1.0', require: 'spree_bank_transfer'
 ```

--- a/Versionfile
+++ b/Versionfile
@@ -1,3 +1,5 @@
+'3.2.x' => { branch: '3-2-updated' }
+'3.1.x' => { branch: '3-1-stable' }
 '3.0.x' => { branch: '3-0-stable' }
 '2.4.x' => { branch: '2-4-stable' }
 '2.3.x' => { branch: '2-3-stable' }

--- a/app/controllers/spree/payments_controller.rb
+++ b/app/controllers/spree/payments_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   class PaymentsController < Spree::StoreController
-    before_filter :authenticate_spree_user!
-    before_filter :find_payment
+    before_action :authenticate_spree_user!
+    before_action :find_payment
 
     def update
       payment_details = PaymentDetails.new(@payment, payment_params)
@@ -10,14 +10,14 @@ module Spree
       else
         flash[:error] = payment_details.errors.to_sentence
       end
-      redirect_to :back
+      redirect_back(fallback_location: root_path)
     end
 
     def find_payment
       @payment = spree_current_user.payments.find_by(number: params[:id])
       unless @payment
         flash[:error] = Spree.t(:payment_not_found)
-        redirect_to :back
+        redirect_back(fallback_location: root_path)
       end
     end
 

--- a/spec/controllers/spree/admin/banks_controller_spec.rb
+++ b/spec/controllers/spree/admin/banks_controller_spec.rb
@@ -25,9 +25,6 @@ describe Spree::Admin::BanksController, type: :controller do
 
     def send_request
       get :index
-
-
-
     end
 
     it "assigns @banks" do
@@ -53,7 +50,7 @@ describe Spree::Admin::BanksController, type: :controller do
     end
 
     def send_request
-      put :toggle_activation, id: "1", format: :js
+      put :toggle_activation, params: { id: "1" }, as: :js
     end
 
     it "toggles activation status of bank" do

--- a/spec/controllers/spree/payments_controller_spec.rb
+++ b/spec/controllers/spree/payments_controller_spec.rb
@@ -55,7 +55,8 @@ describe Spree::PaymentsController, type: :controller do
 
 
     it "creates new payment details" do
-      expect(PaymentDetails).to receive(:new).with(@payment, { 'bank_name' => 'bank_name', 'account_no' => "account_no", 'transaction_reference_no' => "transaction_reference_no" })
+      pr = ActionController::Parameters.new('payment' => { 'bank_name' => 'bank_name', 'account_no' => "account_no", 'transaction_reference_no' => "transaction_reference_no" }).require(:payment).permit!
+      expect(PaymentDetails).to receive(:new).with(@payment, pr)
       send_request
     end
 

--- a/spec/controllers/spree/payments_controller_spec.rb
+++ b/spec/controllers/spree/payments_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe Spree::PaymentsController, type: :controller do
+  # Refer http://stackoverflow.com/a/38233837/306686
+  ## Added to get around redirect_to deprectaion warning for Rspec
+  let(:back) { "http://localhost" }
+
   before do
     allow(controller).to receive(:authenticate_spree_user!).and_return(true)
     @user = mock_model(Spree::User, :generate_spree_api_key! => false, last_incomplete_spree_order: nil)
@@ -9,7 +13,7 @@ describe Spree::PaymentsController, type: :controller do
     @payment = mock_model(Spree::Payment)
     @current_user_payments = double("current_user_payments", find_by: @payment)
     allow(@user).to receive(:payments).and_return(@current_user_payments)
-    request.env["HTTP_REFERER"] = "http://localhost"
+    request.env["HTTP_REFERER"] = back
   end
 
   shared_examples_for "request which finds payment" do
@@ -36,7 +40,7 @@ describe Spree::PaymentsController, type: :controller do
 
       it "redirects to back" do
         send_request
-        expect(response).to redirect_to(:back)
+        expect(response).to redirect_to(back)
       end
     end
   end
@@ -48,7 +52,7 @@ describe Spree::PaymentsController, type: :controller do
     end
 
     def send_request
-      patch :update, id: 'payment_id', payment: { bank_name: 'bank_name', account_no: "account_no", transaction_reference_no: "transaction_reference_no" }
+      patch :update, params: {id: 'payment_id', payment: { bank_name: 'bank_name', account_no: "account_no", transaction_reference_no: "transaction_reference_no" }}
     end
 
     it_behaves_like "request which finds payment"
@@ -86,14 +90,14 @@ describe Spree::PaymentsController, type: :controller do
 
     it "redirects to back" do
       send_request
-      expect(response).to redirect_to(:back)
+      expect(response).to redirect_to(back)
     end
   end
 
   describe "#payment_params" do
     it "permits only bank_name, account_no, transaction_reference_no, deposited_on" do
       controller.params = { payment: { bank_name: 'Bank Name', account_no: 'Account number', transaction_reference_no: "transaction reference number", order_id: 'order_id', deposited_on: 'deposited_on' } }
-      expect(controller.send(:payment_params)).to eq({ "bank_name" => "Bank Name", "account_no" => "Account number", "transaction_reference_no" => "transaction reference number", 'deposited_on' => 'deposited_on' })
+      expect(controller.send(:payment_params).to_h).to eq({ "bank_name" => "Bank Name", "account_no" => "Account number", "transaction_reference_no" => "transaction reference number", 'deposited_on' => 'deposited_on' })
     end
   end
 end

--- a/spree_bank_transfer.gemspec
+++ b/spree_bank_transfer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.2.0.rc1'
+  s.add_dependency 'spree_core', '~> 3.2.0.rc2'
   s.add_dependency 'sqlite3', '~> 1.3.10'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'

--- a/spree_bank_transfer.gemspec
+++ b/spree_bank_transfer.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree-bank-transfer'
-  s.version     = '3.1.0'
+  s.version     = '3.2.0'
   s.summary     = 'Spree extension to create bank transfer payment method.'
   s.description = 'This Spree extension allows admin to provide bank transfer payment method to its users.'
   s.required_ruby_version = '>= 1.9.3'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 3.1.0'
+  s.add_dependency 'spree_core', '~> 3.2.0.rc1'
   s.add_dependency 'sqlite3', '~> 1.3.10'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'


### PR DESCRIPTION
Fixed Rails 5 Deprecation Warnings and Updated README for 3.2.x
Deprecation redirect_to , before_filter
Deprecation use of params hash in spec controller tests
Deprecation of using strong parameters as Hash